### PR TITLE
Update package name in Package.swift

### DIFF
--- a/IntegrationTests/Package.swift
+++ b/IntegrationTests/Package.swift
@@ -11,6 +11,6 @@ let package = Package(
     targets: [
         .target(
             name: "IntegrationTests",
-            dependencies: ["WasmTransformer", "PythonKit"]),
+            dependencies: [.product(name: "WasmTransformer", package: "wasm-transformer"), "PythonKit"]),
     ]
 )

--- a/IntegrationTests/Package.swift
+++ b/IntegrationTests/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "IntegrationTests",
     dependencies: [
         .package(url: "https://github.com/pvieito/PythonKit.git", .revision("b6513c3")),
-        .package(name: "WasmTransformer", path: "../"),
+        .package(name: "wasm-transformer", path: "../"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "WasmTransformer",
+    name: "wasm-transformer",
     products: [
         .library(
             name: "WasmTransformer",


### PR DESCRIPTION
AFAIU it doesn't remove the need to specify the package name when specifying a target dependencies in other projects. But at least it should remove the need to specify the package name explicitly in the repository URL dependency.

Resolves some of #1.